### PR TITLE
fix: Redirect to medium articles

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -24,42 +24,42 @@
   },
   {
     "from": "/3df7ecb58d9c",
-    "to": "/how-to-set-up-continuous-deployment-in-your-home-project-the-easy-way-41b84a467eed",
+    "to": "https://medium.com/@kyle.galbraith/how-to-continuously-deploy-a-static-website-in-style-using-github-and-aws-3df7ecb58d9c",
     "permanent": true
   },
   {
     "from": "/how-to-continuously-deploy-a-static-website-in-style-using-github-and-aws-3df7ecb58d9c",
-    "to": "/how-to-set-up-continuous-deployment-in-your-home-project-the-easy-way-41b84a467eed",
+    "to": "https://medium.com/@kyle.galbraith/how-to-continuously-deploy-a-static-website-in-style-using-github-and-aws-3df7ecb58d9c",
     "permanent": true
   },
   {
     "from": "/5fd4b7c2b896",
-    "to": "/the-reality-of-running-a-production-node-app-on-aws-elastic-beanstalk-55c78b5dad0b",
+    "to": "https://medium.com/@kyle.galbraith/the-aws-guide-to-a-zombie-apocalypse-an-explanation-of-regions-and-availability-zones-5fd4b7c2b896",
     "permanent": true
   },
   {
     "from": "/the-aws-guide-to-a-zombie-apocalypse-an-explanation-of-regions-and-availability-zones-5fd4b7c2b896",
-    "to": "/the-reality-of-running-a-production-node-app-on-aws-elastic-beanstalk-55c78b5dad0b",
+    "to": "https://medium.com/@kyle.galbraith/the-aws-guide-to-a-zombie-apocalypse-an-explanation-of-regions-and-availability-zones-5fd4b7c2b896",
     "permanent": true
   },
   {
     "from": "/d2f54e8b096",
-    "to": "/how-to-host-a-static-website-with-s3-cloudfront-and-route53-7cbb11d4aeea",
+    "to": "https://medium.com/@kyle.galbraith/how-to-make-use-of-cloudfront-for-secure-delivery-of-static-websites-to-the-world-d2f54e8b096",
     "permanent": true
   },
   {
     "from": "/how-to-make-use-of-cloudfront-for-secure-delivery-of-static-websites-to-the-world-d2f54e8b096",
-    "to": "/how-to-host-a-static-website-with-s3-cloudfront-and-route53-7cbb11d4aeea",
+    "to": "https://medium.com/@kyle.galbraith/how-to-make-use-of-cloudfront-for-secure-delivery-of-static-websites-to-the-world-d2f54e8b096",
     "permanent": true
   },
   {
     "from": "/e2b82aa6cd38",
-    "to": "/simple-site-hosting-with-amazon-s3-and-https-5e78017f482a",
+    "to": "https://medium.com/@kyle.galbraith/how-to-host-a-website-on-s3-without-getting-lost-in-the-sea-e2b82aa6cd38",
     "permanent": true
   },
   {
     "from": "/how-to-host-a-website-on-s3-without-getting-lost-in-the-sea-e2b82aa6cd38",
-    "to": "/simple-site-hosting-with-amazon-s3-and-https-5e78017f482a",
+    "to": "https://medium.com/@kyle.galbraith/how-to-host-a-website-on-s3-without-getting-lost-in-the-sea-e2b82aa6cd38",
     "permanent": true
   },
   {

--- a/test.js
+++ b/test.js
@@ -4,22 +4,27 @@ const redirects = JSON.parse(fs.readFileSync('./redirects.json', 'utf8'));
 const fromSlugs = [];
 
 redirects.forEach((obj, i) => {
+  const from = obj.from;
+  const to = obj.to;
+  const mediumRedirect = to.includes('https://medium.com/');
+
   // Skip the first three redirect objects
+  // and DMCA redirects to Medium
   if (i > 2) {
-    const from = obj.from;
-    const to = obj.to;
     
     // 'from' is not '/' or '/ghost'
     assert.notStrictEqual(from, '/');
     assert.notStrictEqual(from, '/ghost');
 
-    // First characters are '/'
-    assert.deepStrictEqual(from[0], '/');
-    assert.deepStrictEqual(to[0], '/');
+    if (!mediumRedirect) {
+      // First characters are '/'
+      assert.deepStrictEqual(from[0], '/');
+      assert.deepStrictEqual(to[0], '/');
 
-    // Last characters are not '/'
-    assert.notStrictEqual(from[from.length - 1], '/');
-    assert.notStrictEqual(to[to.length - 1], '/');
+      // Last characters are not '/'
+      assert.notStrictEqual(from[from.length - 1], '/');
+      assert.notStrictEqual(to[to.length - 1], '/');
+    }
 
     fromSlugs.push(from);
   }


### PR DESCRIPTION
Updated redirects to alternate fCC News articles so they now point to the Medium versions of the original articles. Also modified test.js to check for redirects to Medium.